### PR TITLE
Update runtime to 50

### DIFF
--- a/org.gnome.meld.json
+++ b/org.gnome.meld.json
@@ -1,20 +1,14 @@
 {
     "app-id": "org.gnome.meld",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "meld",
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
-        "/share/pkgconfig",
-        "/share/aclocal",
-        "/man",
-        "/share/man",
-        "/share/gtk-doc",
-        "/share/vala",
-        "*.la",
-        "*.a"
+        "/share/gir-1.0",
+        "/share/man"
     ],
     "finish-args": [
         "--share=ipc",


### PR DESCRIPTION
- Update runtime to 50
- Update shared-modules
- Improve cleanup commands to reduce the Flatpak size
- Drop ineffective cleanup commands